### PR TITLE
Implemented absences command

### DIFF
--- a/cmd/absences.go
+++ b/cmd/absences.go
@@ -21,9 +21,10 @@ const (
 )
 
 type AbsencesCmdOpts struct {
-	format string
-	year   string
-	period AbsencesPeriod
+	format  string
+	year    string
+	period  AbsencesPeriod
+	minRate uint
 }
 
 var (
@@ -65,6 +66,7 @@ func init() {
 		string(ALL),
 		"Period to calculate absences for (all, ete, semestre1, semestre2)",
 	)
+	absencesCmd.Flags().UintVarP(&absencesOpts.minRate, "rate", "r", 0, "Minimum rate to display")
 	rootCmd.AddCommand(absencesCmd)
 }
 
@@ -112,7 +114,7 @@ func printAbsences(absences *parser.AbsenceReport) {
 			selected = true
 		}
 
-		if selected {
+		if selected && absolutePresence >= float64(absencesOpts.minRate) {
 			t.AppendRow(table.Row{
 				a.Name,
 				totalAbsence,

--- a/cmd/absences.go
+++ b/cmd/absences.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/spf13/cobra"
+	"lutonite.dev/gaps-cli/gaps"
+	"lutonite.dev/gaps-cli/parser"
+)
+
+type AbsencesPeriod string
+
+const (
+	ALL        AbsencesPeriod = "all"
+	ETE        AbsencesPeriod = "ete"
+	SEMESTRE_1 AbsencesPeriod = "1"
+	SEMESTRE_2 AbsencesPeriod = "2"
+)
+
+type AbsencesCmdOpts struct {
+	format string
+	year   string
+	period AbsencesPeriod
+}
+
+var (
+	absencesOpts = &AbsencesCmdOpts{}
+	absencesCmd  = &cobra.Command{
+		Use:   "absences",
+		Short: "Allows to consult your absences",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch absencesOpts.period {
+			case ALL, ETE, SEMESTRE_1, SEMESTRE_2:
+				// valid
+			default:
+				return fmt.Errorf("invalid period: %s. Must be one of: all, ete, semestre1, semestre2", absencesOpts.period)
+			}
+
+			cfg := buildTokenClientConfiguration()
+			absencesAction := gaps.NewAbsencesAction(cfg, currentAcademicYear())
+
+			absences, err := absencesAction.FetchAbsences()
+			if err != nil {
+				return fmt.Errorf("couldn't fetch absences: %w", err)
+			}
+			printAbsences(absences)
+			return nil
+		},
+	}
+)
+
+func init() {
+	absencesCmd.Flags().StringVarP(&absencesOpts.format, "format", "o", "table", "Output format (table, json)")
+	absencesCmd.Flags().StringVarP(
+		&absencesOpts.year, "year", "y", absencesOpts.defaultYear(),
+		"Academic year (year at the start of the academic year, e.g. 2020 for 2020-2021 academic year)",
+	)
+	absencesCmd.Flags().StringVarP(
+		(*string)(&absencesOpts.period),
+		"period",
+		"p",
+		string(ALL),
+		"Period to calculate absences for (all, ete, semestre1, semestre2)",
+	)
+	rootCmd.AddCommand(absencesCmd)
+}
+
+func (*AbsencesCmdOpts) defaultYear() string {
+	return fmt.Sprintf("%d", currentAcademicYear())
+}
+
+func printAbsences(absences *parser.AbsenceReport) {
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
+	t.Style().Options.SeparateRows = true
+	t.SetColumnConfigs([]table.ColumnConfig{
+		{Number: 1, AlignHeader: text.AlignCenter},
+		{Number: 2, Align: text.AlignCenter, AlignHeader: text.AlignCenter},
+		{Number: 3, Align: text.AlignCenter, AlignHeader: text.AlignCenter},
+		{Number: 4, Align: text.AlignCenter, AlignHeader: text.AlignCenter},
+	})
+	t.AppendHeader(table.Row{"Course", "Total", "Taux relatif", "Taux absolu"})
+
+	for _, a := range absences.Courses {
+		totalAbsence := a.Total - a.Justified
+		relativePresence, absolutePresence := calculateAbsences(&a)
+
+		getColoredRate := func(rate float64) string {
+			rateStr := fmt.Sprintf("%.2f%%", rate)
+			switch {
+			case rate >= 15:
+				return text.Colors{text.FgRed, text.Bold}.Sprint(rateStr)
+			case rate >= 8:
+				return text.Colors{text.FgYellow}.Sprint(rateStr)
+			default:
+				return text.Colors{text.FgGreen}.Sprint(rateStr)
+			}
+		}
+
+		selected := false
+		switch absencesOpts.period {
+		case ETE:
+			selected = (a.Periods.Ete > 0)
+		case SEMESTRE_1:
+			selected = (a.Periods.Term1 > 0) || (a.Periods.Term2 > 0)
+		case SEMESTRE_2:
+			selected = (a.Periods.Term3 > 0) || (a.Periods.Term4 > 0)
+		default:
+			selected = true
+		}
+
+		if selected {
+			t.AppendRow(table.Row{
+				a.Name,
+				totalAbsence,
+				getColoredRate(relativePresence),
+				getColoredRate(absolutePresence),
+			})
+		}
+	}
+	t.Render()
+}
+
+func calculateAbsences(a *parser.CourseAbsence) (float64, float64) {
+	var relativePresence float64
+	var absolutePresence float64
+	switch absencesOpts.period {
+	case ETE:
+		if a.Periods.Ete != 0 {
+			relativePresence = float64(a.Periods.Ete) / float64(a.RelativePeriods)
+			absolutePresence = float64(a.Periods.Ete) / float64(a.AbsolutePeriods)
+		} else {
+			return 0, 0
+		}
+	case SEMESTRE_1:
+		relativePresence = float64(a.Periods.Term1+a.Periods.Term2) / float64(a.RelativePeriods)
+		absolutePresence = float64(a.Periods.Term1+a.Periods.Term2) / float64(a.AbsolutePeriods)
+	case SEMESTRE_2:
+		relativePresence = float64(a.Periods.Term3+a.Periods.Term4) / float64(a.RelativePeriods)
+		absolutePresence = float64(a.Periods.Term3+a.Periods.Term4) / float64(a.AbsolutePeriods)
+	default:
+		relativePresence = float64(a.Total) / float64(a.RelativePeriods)
+		absolutePresence = float64(a.Total) / float64(a.AbsolutePeriods)
+	}
+	return relativePresence * 100.0, absolutePresence * 100.0
+}

--- a/cmd/absences.go
+++ b/cmd/absences.go
@@ -59,11 +59,12 @@ var (
 )
 
 func init() {
-	absencesCmd.Flags().StringVarP(&absencesOpts.format, "format", "o", "table", "Output format (table, json)")
+	absencesCmd.Flags().StringVarP(&absencesOpts.format, "format", "o", "table",
+		"Output format (table, json) note that other flags do not apply on json format")
 	absencesCmd.Flags().UintVarP(&absencesOpts.year, "year", "y", currentAcademicYear(),
 		"Academic year (year at the start of the academic year, e.g. 2020 for 2020-2021 academic year)")
 	absencesCmd.Flags().StringVarP((*string)(&absencesOpts.semester), "semester", "s", string(ALL),
-		"Period to calculate absences for (all, ete, 1, 2)")
+		"Semester to get absences for (all, ete, 1, 2)")
 	absencesCmd.Flags().UintVarP(&absencesOpts.minRate, "rate", "r", 0, "Minimum rate to display")
 	rootCmd.AddCommand(absencesCmd)
 }
@@ -78,7 +79,7 @@ func printAbsences(absences *parser.AbsenceReport) {
 		{Number: 3, Align: text.AlignCenter, AlignHeader: text.AlignCenter},
 		{Number: 4, Align: text.AlignCenter, AlignHeader: text.AlignCenter},
 	})
-	t.AppendHeader(table.Row{"Course", "Total", "Taux relatif", "Taux absolu"})
+	t.AppendHeader(table.Row{"Course", "Total", "Relative rate", "Absolute rate"})
 
 	for _, a := range absences.Courses {
 		totalAbsence := a.Total - a.Justified

--- a/gaps/absences.go
+++ b/gaps/absences.go
@@ -1,0 +1,53 @@
+package gaps
+
+import (
+	"fmt"
+	"net/url"
+
+	"lutonite.dev/gaps-cli/parser"
+)
+
+type AbsencesAction struct {
+	cfg  *TokenClientConfiguration
+	year uint
+}
+
+func NewAbsencesAction(config *TokenClientConfiguration, year uint) *AbsencesAction {
+	return &AbsencesAction{
+		cfg:  config,
+		year: year,
+	}
+}
+
+func (a *AbsencesAction) FetchAbsences() (*parser.AbsenceReport, error) {
+	req, err := a.cfg.buildRequest("POST", "/consultation/etudiant/")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST rsargs to get all absences
+	// showAllConfig := `["studentAbsGrid_rateSelectorId","studentAbsGrid","410697149756876201",null,null,"2024","0",19686,null]`
+	showAllConfig := fmt.Sprintf(`["studentAbsGrid_rateSelectorId","studentAbsGrid","%d",null,null,"%d","0",19686,null]`, a.cfg.token, a.year)
+
+	data := url.Values{}
+	data.Add("rs", "smartReplacePart")
+	data.Add("rsargs", showAllConfig)
+
+	res, err := a.cfg.doForm(req, data)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	pres, err := parser.FromResponseBody(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	absences, err := pres.Absences()
+	if err != nil {
+		return nil, err
+	}
+	return absences, nil
+
+}

--- a/gaps/absences.go
+++ b/gaps/absences.go
@@ -26,7 +26,8 @@ func (a *AbsencesAction) FetchAbsences() (*parser.AbsenceReport, error) {
 	}
 
 	// POST rsargs to get all absences
-	showAllConfig := fmt.Sprintf(`["studentAbsGrid_rateSelectorId","studentAbsGrid","%d",null,null,"%d","0",19686,null]`, a.cfg.token, a.year)
+	showAllConfig := fmt.Sprintf(`["studentAbsGrid_rateSelectorId","studentAbsGrid","%s",null,null,"%d","0",%d,null]`,
+		a.cfg.token, a.year, a.cfg.studentId)
 
 	data := url.Values{}
 	data.Add("rs", "smartReplacePart")

--- a/gaps/absences.go
+++ b/gaps/absences.go
@@ -26,7 +26,6 @@ func (a *AbsencesAction) FetchAbsences() (*parser.AbsenceReport, error) {
 	}
 
 	// POST rsargs to get all absences
-	// showAllConfig := `["studentAbsGrid_rateSelectorId","studentAbsGrid","410697149756876201",null,null,"2024","0",19686,null]`
 	showAllConfig := fmt.Sprintf(`["studentAbsGrid_rateSelectorId","studentAbsGrid","%d",null,null,"%d","0",19686,null]`, a.cfg.token, a.year)
 
 	data := url.Values{}

--- a/parser/absences.go
+++ b/parser/absences.go
@@ -76,7 +76,7 @@ func parseAbsenceWithJustified(text string, totalJustified *int) int {
 	// Look for pattern like "2 [2]"
 	if matches := regexp.MustCompile(`(\d+)\s*\[(\d+)\]`).FindStringSubmatch(text); matches != nil {
 		justified, _ := strconv.Atoi(matches[2])
-		*totalJustified += justified // Add to total justified
+		*totalJustified += justified
 		total, _ := strconv.Atoi(matches[1])
 		return total
 	}

--- a/parser/absences.go
+++ b/parser/absences.go
@@ -1,0 +1,99 @@
+package parser
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+type AbsenceReport struct {
+	Student     string
+	Orientation string
+	Courses     []CourseAbsence
+}
+
+type CourseAbsence struct {
+	Name    string
+	Periods struct {
+		Ete   int
+		Term1 int
+		Term2 int
+		Term3 int
+		Term4 int
+	}
+	Total           int
+	Justified       int
+	RelativePeriods int
+	AbsolutePeriods int
+}
+
+func (s *Parser) Absences() (*AbsenceReport, error) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(s.src))
+	if err != nil {
+		return nil, err
+	}
+	report := &AbsenceReport{}
+
+	report.Student = doc.Find(".s_cell").First().Text()
+	report.Orientation = doc.Find(".l_cell.s_cell").First().Text()
+
+	doc.Find("tr.a_r_0").Each(func(i int, row *goquery.Selection) {
+		if row.Find("td.l_cell").Length() == 0 {
+			return
+		}
+
+		course := CourseAbsence{}
+
+		courseName := row.Find("td.l_cell:not(.s_cell)").First().Text()
+		course.Name = strings.TrimSpace(courseName)
+
+		cells := row.Find("td.b_cell")
+
+		course.Periods.Ete = parseAbsenceWithJustified(cells.Eq(0).Text(), &course.Justified)
+		course.Periods.Term1 = parseAbsenceWithJustified(cells.Eq(1).Text(), &course.Justified)
+		course.Periods.Term2 = parseAbsenceWithJustified(cells.Eq(2).Text(), &course.Justified)
+		course.Periods.Term3 = parseAbsenceWithJustified(cells.Eq(3).Text(), &course.Justified)
+		course.Periods.Term4 = parseAbsenceWithJustified(cells.Eq(4).Text(), &course.Justified)
+		course.Total = parseAbsence(cells.Eq(5).Text())
+
+		course.RelativePeriods = parseAbsence(cells.Eq(6).Text())
+		course.AbsolutePeriods = parseAbsence(cells.Eq(7).Text())
+
+		report.Courses = append(report.Courses, course)
+	})
+
+	return report, nil
+}
+
+func parseAbsenceWithJustified(text string, totalJustified *int) int {
+	text = strings.TrimSpace(text)
+	if text == "" || text == "&nbsp" {
+		return 0
+	}
+
+	// Look for pattern like "2 [2]"
+	if matches := regexp.MustCompile(`(\d+)\s*\[(\d+)\]`).FindStringSubmatch(text); matches != nil {
+		justified, _ := strconv.Atoi(matches[2])
+		*totalJustified += justified // Add to total justified
+		total, _ := strconv.Atoi(matches[1])
+		return total
+	}
+
+	num, _ := strconv.Atoi(text)
+	return num
+}
+
+func parseAbsence(text string) int {
+	text = strings.TrimSpace(text)
+	if text == "" || text == "&nbsp" {
+		return 0
+	}
+	// Remove any [x] if present and just get the main number
+	if idx := strings.Index(text, "["); idx != -1 {
+		text = strings.TrimSpace(text[:idx])
+	}
+	num, _ := strconv.Atoi(text)
+	return num
+}

--- a/parser/absences.go
+++ b/parser/absences.go
@@ -9,24 +9,24 @@ import (
 )
 
 type AbsenceReport struct {
-	Student     string
-	Orientation string
-	Courses     []CourseAbsence
+	Student     string          `json:"student"`
+	Orientation string          `json:"orientation"`
+	Courses     []CourseAbsence `json:"courses"`
 }
 
 type CourseAbsence struct {
-	Name    string
+	Name    string `json:"name"`
 	Periods struct {
-		Ete   int
-		Term1 int
-		Term2 int
-		Term3 int
-		Term4 int
-	}
-	Total           int
-	Justified       int
-	RelativePeriods int
-	AbsolutePeriods int
+		Ete   int `json:"ete"`
+		Term1 int `json:"term1"`
+		Term2 int `json:"term2"`
+		Term3 int `json:"term3"`
+		Term4 int `json:"term4"`
+	} `json:"periods"`
+	Total           int `json:"total"`
+	Justified       int `json:"justified"`
+	RelativePeriods int `json:"relativePeriods"`
+	AbsolutePeriods int `json:"absolutePeriods"`
 }
 
 func (s *Parser) Absences() (*AbsenceReport, error) {


### PR DESCRIPTION
Hello! I am a student in second year and came across your project recently. I really enjoy it because I find gaps really slow and unpractical to use. The work you did with all the authentication and session token stuff is truly amazing. I am currently using the CLI and thought it was missing a way to get absences so I wrote it.

I tried respecting the format and style you wrote the base CLI in as much as I could. The command allows to get the absences part of the gaps website and store it in structs. It prints the result in a nice table like the grades command. The options are the following: 

**-o, --format string** :      Output format (table, json) note that other flags do not apply on json format (default "table")
**-h, --help** :                      help for absences
**-r, --rate uint** :                Minimum rate to display
**-s, --semester string** :  Semester to get absences for (all, ete, 1, 2) (default "all")
**-y, --year uint** :              Academic year (year at the start of the academic year, e.g. 2020 for 2020-2021 academic year) (default current year)

I would love to hear your thoughts on this. Let me know what you think and don't hesitate if there is any change you would like me to do. 