### PR TITLE
find-free-rooms command

### DIFF
--- a/cmd/find-free-rooms.go
+++ b/cmd/find-free-rooms.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"lutonite.dev/gaps-cli/gaps"
+)
+
+type Location uint8
+
+const (
+	Cheseaux Location = iota
+	StRoch
+)
+
+func (l Location) String() string {
+	switch l {
+	case Cheseaux:
+		return "Cheseaux"
+	case StRoch:
+		return "St-Roch"
+	default:
+		return "Unknown"
+	}
+}
+
+// Semesters are trimesters on GAPS. So for semester 2, it is trimester 3
+func correctSemester(semester uint) uint {
+	if semester == 2 {
+		return 3
+	}
+	return semester
+}
+
+const timeLayout = "15:04"
+
+var (
+	weekdayFlag   string
+	startTimeFlag string
+	endTimeFlag   string
+	siteFlag      string
+	semesterFlag  uint
+
+	findFreeRoomsCmd = &cobra.Command{
+		Use:   "find-free-rooms",
+		Short: "Finds free rooms based on specified criteria",
+		Run: func(cmd *cobra.Command, args []string) {
+			freeStart, err := time.Parse(timeLayout, startTimeFlag)
+			if err != nil {
+				log.WithError(err).Fatalf("Failed to parse start time: %s", startTimeFlag)
+			}
+
+			freeEnd, err := time.Parse(timeLayout, endTimeFlag)
+			if err != nil {
+				log.WithError(err).Errorf("Failed to parse end time: %s", endTimeFlag)
+			}
+
+			var targetSite Location
+			switch siteFlag {
+			case "Cheseaux":
+				targetSite = Cheseaux
+			case "St-Roch":
+				targetSite = StRoch
+			default:
+				log.Fatalf("Invalid site specified: %s. Must be 'Cheseaux' or 'St-Roch'", siteFlag)
+				return
+			}
+
+			validWeekdays := map[string]bool{
+				"Monday": true, "Tuesday": true, "Wednesday": true, "Thursday": true, "Friday": true,
+			}
+			if !validWeekdays[weekdayFlag] {
+				log.Errorf("Invalid weekday specified: %s", weekdayFlag)
+				return
+			}
+
+			if semesterFlag < 0 || semesterFlag > 2 {
+				log.Errorf("Invalid semester specified: %d. Must be between 1 and 3", semesterFlag)
+				return
+			}
+
+			cfg := buildTokenClientConfiguration()
+			registryAction := gaps.NewRegistryAction(cfg, currentAcademicYear())
+
+			registry, err := registryAction.FetchRegistry()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			var freeRooms []string
+
+			weekday := weekdayFlag
+			semester := semesterFlag
+
+			fmt.Printf("Searching for free rooms at %s on %s between %s and %s for semester %d...",
+				targetSite, weekday, freeStart.Format(timeLayout), freeEnd.Format(timeLayout), semester)
+
+			freeStartMinutes := freeStart.Hour()*60 + freeStart.Minute()
+			freeEndMinutes := freeEnd.Hour()*60 + freeEnd.Minute()
+			for _, regRoom := range registry.Rooms {
+				var currentRoomSite Location
+				switch regRoom.Name[0] {
+				case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K':
+					currentRoomSite = Cheseaux
+				default:
+					currentRoomSite = StRoch
+				}
+
+				if currentRoomSite != targetSite {
+					continue
+				}
+
+				roomScheduleAction := gaps.NewRoomScheduleAction(cfg, currentAcademicYear(), correctSemester(semester), regRoom.ID)
+				calendar, err := roomScheduleAction.FetchSchedule()
+				if err != nil {
+					log.WithError(err).Warnf("Failed to fetch schedule for room %s (ID: %d)", regRoom.Name, regRoom.ID)
+					continue
+				}
+
+				isAvailable := true
+				for _, event := range calendar.Events() {
+					start, err := parseDateTime(event.GetProperty("DTSTART").Value)
+					if err != nil {
+						log.WithError(err).Warnf("Failed to parse event start time for room %s", regRoom.Name)
+						continue
+					}
+
+					end, err := parseDateTime(event.GetProperty("DTEND").Value)
+					if err != nil {
+						log.WithError(err).Warnf("Failed to parse event end time for room %s", regRoom.Name)
+						continue
+					}
+
+					if weekday != start.Weekday().String() {
+						continue
+					}
+
+					eventStartMinutes := start.Hour()*60 + start.Minute()
+					eventEndMinutes := end.Hour()*60 + end.Minute()
+
+					if eventStartMinutes < freeEndMinutes && eventEndMinutes > freeStartMinutes {
+						isAvailable = false
+						break
+					}
+				}
+
+				if isAvailable {
+					freeRooms = append(freeRooms, regRoom.Name)
+				}
+			}
+
+			sort.Strings(freeRooms)
+			if len(freeRooms) > 0 {
+				fmt.Printf("\rFound %d free rooms at %s on %s between %s and %s for semester %d:       \n",
+					len(freeRooms), targetSite, weekday, freeStart.Format(timeLayout), freeEnd.Format(timeLayout), semester)
+				for _, roomName := range freeRooms {
+					fmt.Printf("- %s\n", roomName)
+				}
+			} else {
+				fmt.Printf("\nNo free rooms found at %s on %s between %s and %s for semester %d.\n",
+					targetSite, weekday, freeStart.Format(timeLayout), freeEnd.Format(timeLayout), semester)
+			}
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(findFreeRoomsCmd)
+	findFreeRoomsCmd.Flags().StringVarP(&weekdayFlag, "weekday", "w", "Monday", "Day of the week (e.g., Monday)")
+	findFreeRoomsCmd.Flags().StringVarP(&startTimeFlag, "start-time", "s", "08:00", "Start time in HH:MM format")
+	findFreeRoomsCmd.Flags().StringVarP(&endTimeFlag, "end-time", "e", "10:00", "End time in HH:MM format")
+	findFreeRoomsCmd.Flags().StringVarP(&siteFlag, "site", "l", "Cheseaux", "Site location ('Cheseaux' or 'St-Roch')")
+	findFreeRoomsCmd.Flags().UintVarP(&semesterFlag, "semester", "m", 1, "Semester number (0, 1, 2), 0 is summer")
+
+	findFreeRoomsCmd.MarkFlagRequired("weekday")
+	findFreeRoomsCmd.MarkFlagRequired("start-time")
+	findFreeRoomsCmd.MarkFlagRequired("end-time")
+	findFreeRoomsCmd.MarkFlagRequired("semester")
+}

--- a/gaps/registry.go
+++ b/gaps/registry.go
@@ -1,0 +1,52 @@
+package gaps
+
+import (
+	"fmt"
+	"net/url"
+
+	"lutonite.dev/gaps-cli/parser"
+)
+
+type RegistryAction struct {
+	cfg  *TokenClientConfiguration
+	year uint
+}
+
+func NewRegistryAction(config *TokenClientConfiguration, year uint) *RegistryAction {
+	return &RegistryAction{
+		cfg:  config,
+		year: year,
+	}
+}
+
+func (r *RegistryAction) FetchRegistry() (*parser.Registry, error) {
+	req, err := r.cfg.buildRequest("POST", "/consultation/horaires/")
+	if err != nil {
+		return nil, err
+	}
+
+	// POST rsargs to get all sections
+	showAllConfig := fmt.Sprintf(`[%d,2,false,{"0":{"6":{"27":true,"28":true,"29":true,"30":true,"31":true}},"1":{"8":{"8":true,"16":true,"18":true},"9":{"9":true,"32":true,"33":true,"34":true},"10":{"36":true,"37":true,"48":true},"12":{"53":true},"15":{"24":true,"54":true}},"2":{"2":{"35":true,"38":true,"40":true},"14":{"14":true,"49":true,"50":true,"51":true}},"3":{"13":{"13":true}},"4":{"4":{"4":true}},"16":{"2":{"35":true},"10":{"48":true},"15":{"24":true}},"17":{"3":{"3":true}},"63":{"7":{"7":true}},"-1":true},null]`, r.year)
+
+	data := url.Values{}
+	data.Add("rs", "getMenuHoraire")
+	data.Add("rsargs", showAllConfig)
+
+	res, err := r.cfg.doForm(req, data)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	pres, err := parser.FromResponseBody(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	registry, err := pres.Registry()
+	if err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}

--- a/parser/registry.go
+++ b/parser/registry.go
@@ -1,0 +1,100 @@
+package parser
+
+import (
+	"log"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+type RegistryEntry struct {
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
+}
+
+type Registry struct {
+	Teachers map[string]RegistryEntry
+	Students map[string]RegistryEntry
+	Rooms    map[string]RegistryEntry
+}
+
+func (r *Parser) Registry() (*Registry, error) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(r.src))
+	if err != nil {
+		return nil, err
+	}
+
+	directory := &Registry{
+		Teachers: make(map[string]RegistryEntry),
+		Students: make(map[string]RegistryEntry),
+		Rooms:    make(map[string]RegistryEntry),
+	}
+
+	doc.Find(".ulroot > li.submenu.liroot").Each(func(i int, section *goquery.Selection) {
+		section.Find("li.link > a").Each(func(i int, link *goquery.Selection) {
+			href, exists := link.Attr("href")
+			if !exists {
+				return
+			}
+
+			name := strings.TrimSpace(link.Text())
+			if name == "" {
+				return
+			}
+
+			u, err := url.Parse(href)
+			if err != nil {
+				return
+			}
+
+			q := u.Query()
+			entryType := q.Get("type")
+
+			// Skip type=9 (Classes/Teachings)
+			if entryType == "9" {
+				return
+			}
+
+			rawID := q.Get("id")
+			if rawID == "" {
+				return
+			}
+
+			numID, err := strconv.ParseUint(rawID, 10, 32)
+			if err != nil {
+				log.Printf("Failed to parse non-empty ID '%s': %v", rawID, err)
+				return
+			}
+
+			entry := RegistryEntry{
+				ID:   uint(numID),
+				Name: name,
+			}
+
+			switch entryType {
+			case "1":
+				directory.Teachers[name] = entry
+			case "2":
+				directory.Students[name] = entry
+			case "4":
+				directory.Rooms[name] = entry
+			}
+		})
+	})
+	return directory, nil
+}
+
+func getTypeString(typeID uint) string {
+	switch typeID {
+	case 1:
+		return "teacher"
+	case 2:
+		return "student"
+	case 4:
+		return "room"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
I saw the #1 issue and thought I would implement it because it would be really useful. 

For command to work, I needed to write the registry part. It fetches the students, teachers and rooms ids and corresponding names. This is a pretty slow operation but it allows the command not to depend on some cached list.

The command arguments are the following:
```
-e, --end-time string     End time in HH:MM format (default "10:00")
-h, --help                help for find-free-rooms
-m, --semester uint       Semester number (0, 1, 2), 0 is summer (default 1)
-l, --site string         Site location ('Cheseaux' or 'St-Roch') (default "Cheseaux")
-s, --start-time string   Start time in HH:MM format (default "08:00")
-w, --weekday string      Day of the week (e.g., Monday) (default "Monday")
```

The command is really slow (~15sec execution) because it has to fetch the schedules for all rooms.

There are a few things that could be improved but I don't know what is best or haven't found a solution: 
- The output format isn't the best, there probably is a better formatting possible but I don't know how
- There is no way to apply filters on the rooms. Like some rooms might be locked or not correspond to what someone would be looking for. The only thing I can think of would be hard coding the filters

Let me know what you think about it and if you need me to make modifications I will be happy to do so!